### PR TITLE
Add support for creating empty saves

### DIFF
--- a/gui/src/editor/mod.rs
+++ b/gui/src/editor/mod.rs
@@ -112,6 +112,7 @@ impl EditorScreen {
                     tab.display(ui, data, rt, popups)
                 })
             },
+            None,
         );
         self.selected_panel = selected_panel;
 

--- a/gui/src/editor/sessions.rs
+++ b/gui/src/editor/sessions.rs
@@ -147,6 +147,7 @@ impl<'a> EditorTab<'a> for SessionsTab<'a> {
                         &mut data.add_dnl_buf,
                     )
                 },
+                None,
             )
             .response
         } else {

--- a/gui/src/main.rs
+++ b/gui/src/main.rs
@@ -152,6 +152,7 @@ impl App for SaveEditor {
     fn update(&mut self, ctx: &eframe::egui::Context, _frame: &mut eframe::Frame) {
         // Show the main window contents
         CentralPanel::default().show(ctx, |ui| {
+            let mut add_empty_tab = false;
             TabbedContentWidget::show(
                 ui,
                 &mut self.selected_screen,
@@ -184,7 +185,27 @@ impl App for SaveEditor {
                         }
                     }
                 },
+                Some(&mut add_empty_tab),
             );
+            if add_empty_tab {
+                let mut max_file = 0;
+                for (name, _) in &self.screens {
+                    if let Ok(num) = name.parse::<i32>() {
+                        if num >= max_file {
+                            max_file = num + 1;
+                        }
+                    }
+                }
+
+                let file_name = format!("{max_file}.celeste");
+                self.screens.insert(
+                    max_file.to_string(),
+                    ScreenState::Editor(EditorScreen::new(
+                        file_name.clone(),
+                        LoadableFiles::SaveData(file_name, Box::default()),
+                    )),
+                );
+            }
         });
 
         let mut popup_guard = self.popups.blocking_lock();

--- a/lib/src/saves/def/mod.rs
+++ b/lib/src/saves/def/mod.rs
@@ -30,10 +30,12 @@ pub type AreaId = u16;
 pub struct SaveData {
     #[doc(hidden)]
     #[serde(rename = "@xmlns:xsi")]
-    xsi_url: String,
+    /// XML metadata about the xsi library, should always be [crate::saves::ops::XSI_URL]
+    pub(crate) xsi_url: String,
     #[doc(hidden)]
     #[serde(rename(serialize = "@xmlns:xsd", deserialize = "@xmlns:xsd"))]
-    xsd_url: String,
+    /// XML metadata about the xsd library, should always be [crate::saves::ops::XSD_URL]
+    pub(crate) xsd_url: String,
     /// The last celeste version that the save file was opened with
     #[serde(rename = "Version")]
     pub version: String,
@@ -156,10 +158,12 @@ pub struct SaveData {
 pub struct ModSaveData {
     #[doc(hidden)]
     #[serde(rename(serialize = "@xmlns:xsi", deserialize = "@xmlns:xsi"))]
-    xsi_url: String,
+    /// XML metadata about the xsi library, should always be [crate::saves::ops::XSI_URL]
+    pub(crate) xsi_url: String,
     #[doc(hidden)]
     #[serde(rename(serialize = "@xmlns:xsd", deserialize = "@xmlns:xsd"))]
-    xsd_url: String,
+    /// XML metadata about the xsd library, should always be [crate::saves::ops::XSD_URL]
+    pub(crate) xsd_url: String,
     /// Data about all the modded level sets that were loaded last time this save was played on
     #[serde(rename = "LevelSets")]
     #[serde(default)]
@@ -206,14 +210,15 @@ pub struct Assists {
     pub badeline: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum DashMode {
+    #[default]
     Normal,
     Two,
     Infinite,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Flags {
     #[serde(default)]
     #[serde(rename = "string")]
@@ -227,7 +232,7 @@ pub struct VanillaFlagsWrapper {
     pub(crate) flag: VanillaFlags,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Poem {
     #[serde(default)]
     pub(crate) string: Vec<String>,
@@ -247,7 +252,7 @@ pub enum VanillaFlags {
 /// THIS DOES REMOVE THE ERRORING ELEMENTS FROM THE LIST!!!
 ///
 /// Update this comment when you add this to anything else:
-/// [Flags]
+/// - [Flags]
 fn xsi_nil_weird_list_deserialization<'de, D, T: Deserialize<'de> + 'de>(
     deserializer: D,
 ) -> Result<Vec<T>, D::Error>
@@ -274,7 +279,7 @@ impl<'de, T: Deserialize<'de>> Visitor<'de> for WeirdSeqVisitor<'de, T> {
         let mut vec = Vec::new();
         loop {
             // idk if this will break stuff cause we're now ignoring any errors
-            // the only possible error *should* be the one this intended to overcome but idk /shrug
+            // the only likely error *should* be the one this is intended to overcome but idk /shrug
             if let Ok(val) = seq.next_element() {
                 match val {
                     Some(v) => vec.push(v),

--- a/lib/src/saves/def/session.rs
+++ b/lib/src/saves/def/session.rs
@@ -119,7 +119,7 @@ pub struct LevelFlags {
     pub(crate) level_flags: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Strawberries {
     #[serde(default)]
     #[serde(rename = "EntityID")]

--- a/lib/src/saves/def/vanilla.rs
+++ b/lib/src/saves/def/vanilla.rs
@@ -65,7 +65,7 @@ pub struct AreaDef {
     pub sid: Option<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct AreaMode {
     #[serde(flatten)]
     pub stats: AreaModeStats,
@@ -75,7 +75,7 @@ pub struct AreaMode {
     pub checkpoints: Checkpoints,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Checkpoints {
     #[serde(default)]
     #[serde(rename = "string")]

--- a/lib/src/saves/ops/mod.rs
+++ b/lib/src/saves/ops/mod.rs
@@ -6,11 +6,14 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use chrono::NaiveDateTime;
 pub use quick_xml::DeError;
 
 use crate::saves::{
     def::{everest::LevelSetStats, vanilla::AreaStats},
+    util::FileTime,
     AreaCount,
+    Assists,
     DashCount,
     DashMode,
     DeathCount,
@@ -273,7 +276,6 @@ impl SaveData {
 
         self.unlocked_areas = AreaCount::max(self.unlocked_areas, other.unlocked_areas);
 
-
         // Get the areas
         let areas_to_copy = other.all_areas();
         let curr_areas = self.all_areas_mut();
@@ -386,6 +388,44 @@ impl SaveData {
         if self.total_golden_strawberries < other.total_golden_strawberries {
             self.total_golden_strawberries +=
                 other.total_golden_strawberries - self.total_golden_strawberries;
+        }
+    }
+}
+
+// Manual default because we need the urls, version, and names to be specific things
+impl Default for SaveData {
+    fn default() -> Self {
+        Self {
+            xsi_url: XSI_URL.to_owned(),
+            xsd_url: XSD_URL.to_owned(),
+            version: "1.4.0.0".to_owned(),
+            name: "Madeline".to_owned(),
+            time: FileTime(0),
+            last_save: NaiveDateTime::default(),
+            cheat_mode: false,
+            assist_mode: false,
+            variant_mode: false,
+            assists: Default::default(),
+            theo_sister_name: "Alex".to_owned(),
+            unlocked_areas: 0,
+            total_deaths: 0,
+            total_strawberries: 0,
+            total_golden_strawberries: 0,
+            total_jumps: 0,
+            total_wall_jumps: 0,
+            total_dashes: 0,
+            flags: Default::default(),
+            poem: Default::default(),
+            summit_gems: None,
+            revealed_farewell: false,
+            last_area: Default::default(),
+            current_session: None,
+            areas: Default::default(),
+            level_sets: Default::default(),
+            level_set_recycle_bin: Default::default(),
+            has_modded_save_data: false,
+            last_area_safe: None,
+            current_session_safe: None,
         }
     }
 }
@@ -555,6 +595,18 @@ impl ModSaveData {
     }
 }
 
+impl Default for ModSaveData {
+    fn default() -> Self {
+        Self {
+            xsi_url: XSI_URL.to_owned(),
+            xsd_url: XSD_URL.to_owned(),
+            level_sets: Default::default(),
+            level_set_recycle_bin: Default::default(),
+            last_area_safe: None,
+        }
+    }
+}
+
 impl Display for DashMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", match self {
@@ -616,5 +668,25 @@ impl Deref for Poem {
 impl DerefMut for Poem {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.string
+    }
+}
+
+impl Default for Assists {
+    fn default() -> Self {
+        Self {
+            game_speed: 10,
+            invincible: false,
+            dash_mode: Default::default(),
+            dash_assist: false,
+            infinite_stamina: false,
+            mirror_mode: false,
+            full_dashing: false,
+            invisible_motion: false,
+            no_grabbing: false,
+            low_friction: false,
+            super_dash: false,
+            hiccups: false,
+            badeline: false,
+        }
     }
 }

--- a/lib/src/saves/ops/vanilla.rs
+++ b/lib/src/saves/ops/vanilla.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use crate::saves::def::vanilla::*;
+use crate::saves::{def::vanilla::*, util::FileTime};
 
 const VANILLA_SIDS: [&str; 11] = [
     "Celeste/0-Intro",
@@ -25,15 +25,60 @@ impl AreaDef {
             .as_deref()
             .unwrap_or_else(|| VANILLA_SIDS[self.id as usize])
     }
+
+    /// Creates a new AreaDef for a given sid
+    ///
+    /// `vanilla` determines whether or not the `sid` field is present.
+    ///
+    /// Note that this only works for vanilla SIDs since there does not seem to be a consistent way to
+    /// generate the `id` field for modded areas.
+    pub fn for_sid(sid: &str, vanilla: bool) -> Option<AreaDef> {
+        if VANILLA_SIDS.contains(&sid) {
+            Some(AreaDef {
+                id: VANILLA_SIDS.iter().position(|s| *s == sid).unwrap() as u16,
+                cassette: false,
+                sid: if !vanilla { Some(sid.to_owned()) } else { None },
+            })
+        } else {
+            None
+        }
+    }
 }
 
 impl AreaRef {
     /// Gets a reference to an sid for the level
     pub fn sid(&self) -> &str {
-        // see the comment for AreaDef::sid
+        // We just use vanilla level sids since sid is only None in vanilla saves
+        // Or manually edited saves
         self.sid
             .as_deref()
             .unwrap_or_else(|| VANILLA_SIDS[self.id as usize])
+    }
+
+    /// Creates an AreaRef for a given sid, mode, and whether to format it for a vanilla session or not
+    ///
+    /// `vanilla` determines whether or not the `sid` field is present.
+    ///
+    /// Note that this only works for vanilla SIDs since there does not seem to be a consistent way to
+    /// generate the `id` field for modded areas.
+    pub fn for_sid(sid: &str, mode: AreaModeType, vanilla: bool) -> Option<AreaRef> {
+        if VANILLA_SIDS.contains(&sid) {
+            Some(AreaRef {
+                id: VANILLA_SIDS.iter().position(|s| *s == sid).unwrap() as u16,
+                mode,
+                sid: if !vanilla { Some(sid.to_owned()) } else { None },
+            })
+        } else {
+            None
+        }
+    }
+}
+
+// We say the default is just providing a reference to 0-Intro
+impl Default for AreaRef {
+    fn default() -> Self {
+        // Unwrap is safe since we know the sid is in the array
+        AreaRef::for_sid(VANILLA_SIDS[0], AreaModeType::Normal, true).unwrap()
     }
 }
 
@@ -51,6 +96,36 @@ impl DerefMut for Areas {
     }
 }
 
+// Default areas is just a list of all vanilla areas
+// arguably it should be an empty list since level sets should have it be empty but
+// whatever.
+impl Default for Areas {
+    fn default() -> Self {
+        let mut vanilla_areas = Vec::with_capacity(VANILLA_SIDS.len());
+
+        for sid in VANILLA_SIDS {
+            // unwrap is safe because we're pulling from VANILLA_SIDS
+            vanilla_areas.push(AreaStats::for_sid(sid, true).unwrap())
+        }
+
+        Self {
+            areas: vanilla_areas,
+        }
+    }
+}
+
+impl AreaStats {
+    /// Creates an AreaStats for a given sid
+    ///
+    /// `vanilla` is used to determine the format of the inner [AreaDef]
+    pub fn for_sid(sid: &str, vanilla: bool) -> Option<AreaStats> {
+        Some(AreaStats {
+            def: AreaDef::for_sid(sid, vanilla)?,
+            modes: Default::default(),
+        })
+    }
+}
+
 impl Deref for Modes {
     type Target = Vec<AreaMode>;
 
@@ -62,6 +137,36 @@ impl Deref for Modes {
 impl DerefMut for Modes {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.modes
+    }
+}
+
+// Default for modes is just 3 defaulted AreaModes
+// this is the AreaMode for intro, hopefully the game handles this properly
+impl Default for Modes {
+    fn default() -> Self {
+        Self {
+            modes: vec![AreaMode::default(); 3],
+        }
+    }
+}
+
+// Pretty sensable default here
+// I think I could derive default on this but I don't want to put default on FileTime
+impl Default for AreaModeStats {
+    fn default() -> Self {
+        Self {
+            total_strawberries: 0,
+            completed: false,
+            single_run_completed: false,
+            full_clear: false,
+            deaths: 0,
+            time_played: FileTime(0),
+            best_time: FileTime(0),
+            best_full_clear_time: FileTime(0),
+            best_dashes: 0,
+            best_deaths: 0,
+            heart_gem: false,
+        }
     }
 }
 


### PR DESCRIPTION
Closes #2 
Adds `Default` impl for `SaveData` and related structs.

Also adds support for creating new empty save files in the gui editor.

Currently fails fmt check but the fix there would touch pretty much every file and I want to do that as a master commit.